### PR TITLE
feat: added dockerfile and docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# --- Build stage ---
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o fi-mcp-server main.go
+
+# --- Runtime stage ---
+FROM gcr.io/distroless/base-debian11
+WORKDIR /app
+COPY --from=builder /app/fi-mcp-server ./
+COPY --from=builder /app/static ./static
+COPY --from=builder /app/test_data_dir ./test_data_dir
+EXPOSE 8080
+ENV FI_MCP_PORT=8080
+ENTRYPOINT ["/app/fi-mcp-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   fi-mcp-dev:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  fi-mcp-dev:
+    build: .
+    ports:
+      - "8081:8080"
+    environment:
+      - FI_MCP_PORT=8080
+    volumes:
+      - ./static:/app/static
+      - ./test_data_dir:/app/test_data_dir


### PR DESCRIPTION
This pull request introduces Docker support for the project, including a multi-stage `Dockerfile` for building and running the application, and a `docker-compose.yml` file for local development. These changes aim to streamline the deployment process and improve the developer experience.

### Docker support:

* **Multi-stage `Dockerfile`**: Added a `Dockerfile` that uses a build stage with the `golang:1.23` image to compile the application and a runtime stage based on `distroless/base-debian11` for a minimal production image. The runtime stage includes the compiled binary and necessary assets (`static` and `test_data_dir`) and exposes port 8080.

* **`docker-compose.yml` for local development**: Added a `docker-compose.yml` file to simplify local development. It defines a service (`fi-mcp-dev`) that builds the application, maps port 8081 on the host to port 8080 in the container, and mounts local directories (`static` and `test_data_dir`) to ensure changes are reflected without rebuilding the image.